### PR TITLE
Removed `API.plist` from source control, fixes #7.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
-/APIClient/Pods
-/APIClient/ApiClient.xcworkspace/xcuserdata/
+/ApiClient/Pods
+/ApiClient/ApiClient.xcworkspace/xcuserdata/
+/ApiClient/Tests/API.plist


### PR DESCRIPTION
The `API.plist` contains the API key for the **SchedJoules API**, which is unique to every customer. We decided not to use the test key to make sure API functionality is not limited, and fully featured unit tests can be performed.

The `API.plist` should look like this:

```
<plist version="1.0">
<dict>
	<key>API_KEY</key>
	<string>YOUR_KEY_HERE</string>
</dict>
</plist>
```