### PR TITLE
Validate domain of query URLs.

### DIFF
--- a/ApiClient/Source/ApiError.swift
+++ b/ApiClient/Source/ApiError.swift
@@ -32,4 +32,6 @@ public enum ApiError: Error {
     case emptyResponseData
     /// Error handling the result by the passed in query.
     case errorHandlingResult
+    /// The URL of the passed in query is not in the `schedjoules.com` domain.
+    case invalidDomain
 }

--- a/ApiClient/Source/SchedJoulesApi.swift
+++ b/ApiClient/Source/SchedJoulesApi.swift
@@ -30,6 +30,7 @@ import enum Result.Result
 public final class SchedJoulesApi: Api {
     private let accessToken: String
     private let sessionManager: Alamofire.SessionManager
+    private let apiDomain = ".schedjoules.com"
     
     // Initiliaze with an access token
     public required init (accessToken: String) {
@@ -49,6 +50,11 @@ public final class SchedJoulesApi: Api {
     
     // Execute a request object
     public func execute<T: Query> (query: T, completion: @escaping (Result<T.Result,ApiError>) -> Void) {
+        // Check if the url of the query is in the right domain
+        if query.url.host!.suffix(apiDomain.count) != apiDomain {
+            completion(.failure(ApiError.invalidDomain))
+        }
+        
         // Set required HTTP headers
         var headers = Alamofire.SessionManager.defaultHTTPHeaders
         headers["Authorization"] = "Token token=\(accessToken)"


### PR DESCRIPTION
Check that every query's URL is in the `.schedjoules.com` domain.