### PR TITLE
Return a concrete type as query `Result`, fixes #69.

### DIFF
--- a/ApiClient/Source/Localization/Models/JSON/JSONCountry.swift
+++ b/ApiClient/Source/Localization/Models/JSON/JSONCountry.swift
@@ -25,11 +25,11 @@
 
 import Foundation
 
-struct JSONCountry: Country {
+public struct JSONCountry: Country {
     // Required properties
-    let name: String
-    let code: String
-    let icon: URL?
+    public let name: String
+    public let code: String
+    public let icon: URL?
 }
 
 // MARK: - Decodable protocol
@@ -41,7 +41,7 @@ extension JSONCountry: Decodable {
         case icon
     }
     
-    init(from decoder: Decoder) throws {
+    public init(from decoder: Decoder) throws {
         // Get data container
         let container = try decoder.container(keyedBy: PageKeys.self)
         

--- a/ApiClient/Source/Localization/Models/JSON/JSONLanguage.swift
+++ b/ApiClient/Source/Localization/Models/JSON/JSONLanguage.swift
@@ -25,11 +25,11 @@
 
 import Foundation
 
-struct JSONLanguage: Language {
+public struct JSONLanguage: Language {
     // Required properties
-    let name: String
-    let code: String
-    let icon: URL? // Only included to satisfy protocol requirements
+    public let name: String
+    public let code: String
+    public let icon: URL? // Only included to satisfy protocol requirements
 }
 
 // MARK: - Decodable protocol
@@ -40,7 +40,7 @@ extension JSONLanguage: Decodable {
         case code = "iso_639_1"
     }
     
-    init(from decoder: Decoder) throws {
+    public init(from decoder: Decoder) throws {
         // Get data container
         let container = try decoder.container(keyedBy: PageKeys.self)
         

--- a/ApiClient/Source/Localization/Queries/SupportedCountriesQuery.swift
+++ b/ApiClient/Source/Localization/Queries/SupportedCountriesQuery.swift
@@ -27,7 +27,7 @@ import Foundation
 import Alamofire
 
 public final class SupportedCountriesQuery: Query {
-    public typealias Result = [Country]
+    public typealias Result = [JSONCountry]
     
     public let url: URL = URL(string:"https://api.schedjoules.com/countries")!
     public let method: HTTPMethod = .get
@@ -35,7 +35,7 @@ public final class SupportedCountriesQuery: Query {
     public let parameters: Parameters = [:]
     public let headers: HTTPHeaders = ["Accept" : "application/json"]
     
-    public func handleResult(with data: Data) -> [Country]? {
+    public func handleResult(with data: Data) -> [JSONCountry]? {
         return try? JSONDecoder().decode([JSONCountry].self, from: data)
     }
     

--- a/ApiClient/Source/Localization/Queries/SupportedLanguagesQuery.swift
+++ b/ApiClient/Source/Localization/Queries/SupportedLanguagesQuery.swift
@@ -27,7 +27,7 @@ import Foundation
 import Alamofire
 
 public final class SupportedLanguagesQuery: Query {
-    public typealias Result = [Language]
+    public typealias Result = [JSONLanguage]
     
     public let url: URL = URL(string:"https://api.schedjoules.com/languages")!
     public let method: HTTPMethod = .get
@@ -35,7 +35,7 @@ public final class SupportedLanguagesQuery: Query {
     public let parameters: Parameters = [:]
     public let headers: HTTPHeaders = ["Accept" : "application/json"]
     
-    public func handleResult(with data: Data) -> [Language]? {
+    public func handleResult(with data: Data) -> [JSONLanguage]? {
         return try? JSONDecoder().decode([JSONLanguage].self, from: data)
     }
     

--- a/SchedJoulesApiClient.podspec
+++ b/SchedJoulesApiClient.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'SchedJoulesApiClient'
-  s.version          = '0.6.2'
+  s.version          = '0.7'
   s.summary          = 'The ApiClient for the SchedJoules API, written in Swift.'
  
   s.description      = <<-DESC


### PR DESCRIPTION
- Also updated the `.podspec` to version 0.7.
- Made the models `public`.