### PR TITLE
#81 Crash when subscription returns an error instead of data parsable to JSONSubscription

### DIFF
--- a/ApiClient/Source/Subscriptions/Queries/SubscriptionStatusQuery.swift
+++ b/ApiClient/Source/Subscriptions/Queries/SubscriptionStatusQuery.swift
@@ -44,7 +44,12 @@ public final class SubscriptionStatusQuery: Query {
     }
     
     public func handleResult(with data: Data) -> Subscription? {
-        return try! JSONDecoder().decode(JSONSubscription.self, from: data)
+        do {
+            let subscription = try JSONDecoder().decode(JSONSubscription.self, from: data)
+            return subscription
+        } catch {
+            return nil
+        }
     }
 
 }


### PR DESCRIPTION
Fix crash found when testing api keys, and getting an error
    subscriptionStatusCode = 404;
    subscriptionStatusMessage = "No record present";

Instead of data that can be parsed into a JSONSubscription structure, which is:
    let subscriptionId: String
    let expirationDate: TimeInterval
    let purchaseDate: TimeInterval
    let subscriptionStatusCode: Int
    let subscriptionStatusMessage: String
    let transactionIds: [UInt64]


To test run the Query test `testSubscriptionStatusQuery()`replacing the subscriptionId for any string that is not a real subscription Id (like 123), confirm that the test fails but the api doesn't crash.

with the old setup you would get error:
Fatal error: 'try!' expression unexpectedly raised an error: Swift.DecodingError.keyNotFound(PageKeys(stringValue: "subscriptionId", intValue: nil), Swift.DecodingError.Context(codingPath: [], debugDescription: "No value associated with key PageKeys(stringValue: \"subscriptionId\", intValue: nil) (\"subscriptionId\").", underlyingError: nil)): file /Users/edhoru/Documents/GitHub/swift-api-client/ApiClient/Source/Subscriptions/Queries/SubscriptionStatusQuery.swift, line 47
2019-07-26 05:29:03.877891-0500 ApiClient[5251:3056085] Fatal error: 'try!' expression unexpectedly raised an error: Swift.DecodingError.keyNotFound(PageKeys(stringValue: "subscriptionId", intValue: nil), Swift.DecodingError.Context(codingPath: [], debugDescription: "No value associated with key PageKeys(stringValue: \"subscriptionId\", intValue: nil) (\"subscriptionId\").", underlyingError: nil)): file /Users/edhoru/Documents/GitHub/swift-api-client/ApiClient/Source/Subscriptions/Queries/SubscriptionStatusQuery.swift, line 47
