### PR TITLE
#93 Reduce compatibility requirement to 11.0

### DIFF
--- a/ApiClient/ApiClient.xcodeproj/project.pbxproj
+++ b/ApiClient/ApiClient.xcodeproj/project.pbxproj
@@ -862,6 +862,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = H4FCPLHYSF;
 				INFOPLIST_FILE = "$(SRCROOT)/Example/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.schedjoules.ApiClient;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -878,6 +879,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = H4FCPLHYSF;
 				INFOPLIST_FILE = "$(SRCROOT)/Example/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.schedjoules.ApiClient;
 				PRODUCT_NAME = "$(TARGET_NAME)";


### PR DESCRIPTION
Based on clients compatibility reduce the requirement to 11.0 to make it easier for clients to use.