### PR TITLE
#96 Fix for date crash on Event.swift reported by user

### DIFF
--- a/ApiClient/Source/Calendar/iCalendarParser/Event.swift
+++ b/ApiClient/Source/Calendar/iCalendarParser/Event.swift
@@ -39,11 +39,14 @@ public final class Event {
     
     private func dateFrom(parsedLine: ParsedLine) -> Date {
         let dateFormatter = DateFormatter()
+        dateFormatter.locale = Locale(identifier: "en_US_POSIX")
+        
         if isDateAllDay(line: parsedLine){
             dateFormatter.dateFormat = "yyyyMMdd"
         } else {
             dateFormatter.dateFormat = "yyyyMMdd'T'HHmmssZ"
         }
+        
         return dateFormatter.date(from: parsedLine.value)!
     }
     


### PR DESCRIPTION
The crash was reported by a user but I wasn't able to reproduce, here is the message and the user's proposed solution:

```
Just to update you I have added the line
        
        dateFormatter.locale = Locale(identifier: "en_US_POSIX")
        
To dateFrom function in Event.swift file of the SchedJoulesApiClient.

private func dateFrom(parsedLine: ParsedLine) -> Date {
        let dateFormatter = DateFormatter()
        
        dateFormatter.locale = Locale(identifier: "en_US_POSIX")
        
        if isDateAllDay(line: parsedLine){
            dateFormatter.dateFormat = "yyyyMMdd"
        } else {
            dateFormatter.dateFormat = "yyyyMMdd'T'HHmmssZ"
        }
        
        return dateFormatter.date(from: parsedLine.value)!
    }

It would appear that when a DateFormatter is initialised, it will by default have the users locale (for me here in the UK it was "en_GB").

I assume that the date strings sent to users from the SchedJoules servers, (which are then being parsed to get the actual Date object) are always of the same format, regardless to which country around the world they have downloaded the CalendarStore onto their device. 

So it makes sense to have that locale set to  "en_US_POSIX" for all users before setting the dateFormat to"yyyyMMdd'T'HHmmssZ" . So it is consistent everywhere and avoid weird cases such as the crash I was getting.

So along with a few other code changes I have made myself (which I sent you a list of before), we now appear to have a working CalendarStore 😀
``` 