### PR TITLE
Update SchedJoulesApiClient to 0.8.2

### DIFF
--- a/SchedJoulesApiClient.podspec
+++ b/SchedJoulesApiClient.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'SchedJoulesApiClient'
-  s.version          = '0.8.1'
+  s.version          = '0.8.2'
   s.summary          = 'The ApiClient for the SchedJoules API, written in Swift.'
  
   s.description      = <<-DESC


### PR DESCRIPTION
This update includes the updated suggested by the Readdable team: https://github.com/schedjoules/swift-api-client/pull/104